### PR TITLE
Disable cache by default when not in watch mode

### DIFF
--- a/bin/sourcebit.js
+++ b/bin/sourcebit.js
@@ -9,15 +9,21 @@ commander
   .version(pkg.version)
   .command("fetch")
   .option("-c, --configPath", "specify the location of the configuration file")
+  .option(
+    "-C, --cache",
+    "force Sourcebit to use a filesystem cache, even when `watch` is disabled"
+  )
   .option("-w, --watch", "run continuously in watch mode")
   .option("-q, --quiet", "disable logging messages to the console")
-  .action(({ configPath: customConfigPath, watch }) => {
+  .action(({ cache, configPath: customConfigPath, quiet, watch }) => {
     const configPath = path.resolve(
       process.cwd(),
       customConfigPath || "sourcebit.js"
     );
     const config = require(configPath);
     const runtimeParameters = {
+      cache,
+      quiet,
       watch
     };
 

--- a/lib/sourcebit.js
+++ b/lib/sourcebit.js
@@ -29,6 +29,12 @@ class Sourcebit {
     this.pluginBlocks = [];
     this.pluginModules = {};
     this.runtimeParameters = runtimeParameters;
+
+    this.isCacheEnabled = Boolean(
+      runtimeParameters.cache === undefined
+        ? runtimeParameters.watch
+        : runtimeParameters.cache
+    );
   }
 
   async bootstrapAll() {
@@ -94,7 +100,7 @@ class Sourcebit {
   }
 
   loadContextFromCache() {
-    if (this.runtimeParameters.cache === false) return;
+    if (!this.isCacheEnabled) return;
 
     try {
       const data = fs.readFileSync(this.cacheFilePath, "utf8");
@@ -158,7 +164,7 @@ class Sourcebit {
   }
 
   saveContextToCache() {
-    if (this.runtimeParameters.cache === false) return;
+    if (!this.isCacheEnabled) return;
 
     const serializedCache = JSON.stringify(this.context);
 

--- a/lib/sourcebit.test.js
+++ b/lib/sourcebit.test.js
@@ -189,7 +189,11 @@ describe("`bootstrapAll()`", () => {
       plugins: [{ module: mockPlugin1 }, { module: mockPlugin2 }]
     };
 
-    const sourcebit = new Sourcebit();
+    const sourcebit = new Sourcebit({
+      runtimeParameters: {
+        cache: true
+      }
+    });
 
     sourcebit.loadPlugins(config.plugins);
 
@@ -268,7 +272,7 @@ describe("`bootstrapAll()`", () => {
 });
 
 describe("cache", () => {
-  describe("if `runtimeParameters.cache` is `false`", () => {
+  describe("if `runtimeParameters.cache` is `false` or unset", () => {
     test("does not populate context with cache file's contents", () => {
       mockCache = {
         "sourcebit-source-periodic-table": {
@@ -276,15 +280,18 @@ describe("cache", () => {
         }
       };
 
-      const sourcebit = new Sourcebit({
+      const sourcebit1 = new Sourcebit({
         runtimeParameters: {
           cache: false
         }
       });
+      const sourcebit2 = new Sourcebit();
 
-      sourcebit.loadContextFromCache();
+      sourcebit1.loadContextFromCache();
+      sourcebit2.loadContextFromCache();
 
-      expect(sourcebit.context).toEqual({});
+      expect(sourcebit1.context).toEqual({});
+      expect(sourcebit2.context).toEqual({});
     });
 
     test("does not persist context to cache file", async () => {
@@ -306,31 +313,41 @@ describe("cache", () => {
           }
         }
       ];
-      const sourcebit = new Sourcebit({
+      const sourcebit1 = new Sourcebit({
         runtimeParameters: {
           cache: false
         }
       });
+      const sourcebit2 = new Sourcebit();
 
-      sourcebit.loadPlugins(plugins);
+      sourcebit1.loadPlugins(plugins);
+      sourcebit2.loadPlugins(plugins);
 
-      await sourcebit.bootstrapAll();
+      await sourcebit1.bootstrapAll();
+      await sourcebit2.bootstrapAll();
 
       expect(fs.writeFileSync).not.toHaveBeenCalled();
     });
   });
 
-  describe("if `runtimeParameters.cache` is `true` or unset", () => {
+  describe("if `runtimeParameters.cache` or `runtimeParameters.watch` are `true`", () => {
     test("populates context with cache file's contents", () => {
-      const sourcebit = new Sourcebit({
+      const sourcebit1 = new Sourcebit({
         runtimeParameters: {
           cache: true
         }
       });
+      const sourcebit2 = new Sourcebit({
+        runtimeParameters: {
+          watch: true
+        }
+      });
 
-      sourcebit.loadContextFromCache();
+      sourcebit1.loadContextFromCache();
+      sourcebit2.loadContextFromCache();
 
-      expect(sourcebit.context).toEqual(mockCache);
+      expect(sourcebit1.context).toEqual(mockCache);
+      expect(sourcebit2.context).toEqual(mockCache);
     });
 
     test("fails gracefully if there's an error when reading/parsing the cache file", async () => {
@@ -446,7 +463,11 @@ describe("`getContext()`", () => {
       }
     };
 
-    const sourcebit = new Sourcebit();
+    const sourcebit = new Sourcebit({
+      runtimeParameters: {
+        cache: true
+      }
+    });
 
     await sourcebit.bootstrapAll();
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcebit",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sourcebit",
-  "version": "0.7.1",
+  "version": "0.8.0",
   "description": "Sourcebit helps developers build data-driven JAMstack sites by pulling data from any third-party resource",
   "main": "index.js",
   "bin": {


### PR DESCRIPTION
This PR disables the local filesystem cache by default, except when `--watch` is enabled. Also, it's possible to force Sourcebit to use the cache file when not in watch mode by using the `--cache` flag.

Unit tests updated accordingly.