### PR TITLE
Add onTransformEnd method

### DIFF
--- a/lib/sourcebit.js
+++ b/lib/sourcebit.js
@@ -245,15 +245,15 @@ class Sourcebit {
     try {
       const data = await queue;
 
-      onTransformEndCallbacks.forEach(({ args, callback }) => {
-        callback({ ...args, data });
-      });
-
       finishTransform();
 
       if (Array.isArray(data.files)) {
         await this.writeFiles(data.files);
       }
+
+      onTransformEndCallbacks.forEach(({ args, callback }) => {
+        callback({ ...args, data });
+      });
 
       if (typeof this.onTransform === "function") {
         this.onTransform(null, data);

--- a/lib/sourcebit.js
+++ b/lib/sourcebit.js
@@ -194,6 +194,7 @@ class Sourcebit {
       objects: []
     };
     const contextSnapshot = cloneDeep(this.context);
+    const onTransformEndCallbacks = [];
     const queue = this.pluginBlocks.reduce((queue, pluginBlock, index) => {
       // If the plugin hasn't been bootstrapped, we don't want to run its
       // transform method just yet.
@@ -207,6 +208,18 @@ class Sourcebit {
 
         if (typeof plugin.transform !== "function") {
           return data;
+        }
+
+        if (typeof plugin.onTransformEnd === "function") {
+          onTransformEndCallbacks.push({
+            args: {
+              debug: this.getDebugMethodForPlugin(pluginName),
+              getPluginContext: () => contextSnapshot[pluginName] || {},
+              log: this.logFromPlugin.bind(this),
+              options: this.parsePluginOptions(plugin, pluginBlock.options)
+            },
+            callback: plugin.onTransformEnd
+          });
         }
 
         return plugin.transform({
@@ -231,6 +244,10 @@ class Sourcebit {
 
     try {
       const data = await queue;
+
+      onTransformEndCallbacks.forEach(({ args, callback }) => {
+        callback({ ...args, data });
+      });
 
       finishTransform();
 

--- a/lib/sourcebit.test.js
+++ b/lib/sourcebit.test.js
@@ -888,6 +888,71 @@ describe("`transform()`", () => {
     expect(error).toBeInstanceOf(Error);
     expect(callbackData).not.toBeDefined();
   });
+
+  test("calls the `onTransformEndFn` callback of each plugin, if defined, when `transform` has finished running", async () => {
+    const onTransformEndFn = jest.fn();
+    const plugins = [
+      {
+        module: {
+          name: "sourcebit-test1",
+          onTransformEnd: onTransformEndFn,
+          transform: async ({ data }) => {
+            return {
+              ...data,
+              elements: [{ name: "Lead" }]
+            };
+          }
+        }
+      },
+      {
+        module: {
+          name: "sourcebit-test2",
+          onTransformEnd: onTransformEndFn,
+          transform: ({ data }) => {
+            return {
+              ...data,
+              elements: data.elements.concat({
+                name: "Rhenium"
+              })
+            };
+          }
+        }
+      },
+      {
+        module: {
+          name: "sourcebit-test3",
+          onTransformEnd: onTransformEndFn,
+          transform: ({ data }) => {
+            return {
+              ...data,
+              elements: data.elements.concat({
+                name: "Osmium"
+              })
+            };
+          }
+        }
+      }
+    ];
+    const callback = jest.fn();
+    const sourcebit = new Sourcebit();
+
+    sourcebit.onTransform = callback;
+    sourcebit.loadPlugins(plugins);
+
+    await sourcebit.bootstrapAll();
+
+    const data = await sourcebit.transform();
+
+    expect(onTransformEndFn).toHaveBeenCalledTimes(3);
+
+    onTransformEndFn.mock.calls.forEach(call => {
+      expect(call[0].debug).toBeInstanceOf(Function);
+      expect(call[0].getPluginContext).toBeInstanceOf(Function);
+      expect(call[0].log).toBeInstanceOf(Function);
+      expect(call[0].options).toEqual({});
+      expect(call[0].data).toEqual(data);
+    });
+  });
 });
 
 describe("writing files", () => {


### PR DESCRIPTION
This PR adds support for a `onTransformEnd` method which, when implemented by a plugin, will be executed every time `transform` finishes running for all plugins.