### PR TITLE
Use value of environment variable as default value

### DIFF
--- a/lib/sourcebit.js
+++ b/lib/sourcebit.js
@@ -131,15 +131,19 @@ class Sourcebit {
         const overrides = {};
 
         Object.keys(optionsSchema).forEach(key => {
-            if (optionsSchema[key].default !== undefined) {
-                defaults[key] = optionsSchema[key].default;
+            const option = optionsSchema[key];
+
+            // If the option defines an `env` property and there's an environment variable defined with that name, we'll use
+            // that as the default value. Otherwise, the default value will be the one defined by the `default` property, if
+            // one is defined.
+            if (option.env && process.env[option.env] !== undefined) {
+                defaults[key] = process.env[option.env];
+            } else if (option.default !== undefined) {
+                defaults[key] = option.default;
             }
 
-            if (
-                typeof optionsSchema[key].runtimeParameter === 'string' &&
-                this.runtimeParameters[optionsSchema[key].runtimeParameter] !== undefined
-            ) {
-                overrides[key] = this.runtimeParameters[optionsSchema[key].runtimeParameter];
+            if (typeof option.runtimeParameter === 'string' && this.runtimeParameters[option.runtimeParameter] !== undefined) {
+                overrides[key] = this.runtimeParameters[option.runtimeParameter];
             }
         });
 

--- a/lib/sourcebit.js
+++ b/lib/sourcebit.js
@@ -135,7 +135,7 @@ class Sourcebit {
 
             // If the option defines an `env` property and there's an environment variable defined with that name, we'll use
             // that as the default value. Otherwise, the default value will be the one defined by the `default` property, if
-            // one is defined.
+            // one is set.
             if (option.env && process.env[option.env] !== undefined) {
                 defaults[key] = process.env[option.env];
             } else if (option.default !== undefined) {

--- a/lib/sourcebit.test.js
+++ b/lib/sourcebit.test.js
@@ -31,6 +31,8 @@ const mockOra = {
 
 jest.mock('ora', () => jest.fn(() => mockOra));
 
+process.env.FORBIDDEN_ELEMENT = 'Cadmium';
+
 const Sourcebit = require('./sourcebit');
 
 beforeEach(() => {
@@ -89,9 +91,8 @@ describe('`bootstrapAll()`', () => {
         await sourcebit.bootstrapAll();
     });
 
-    test('passes an `options` block plugins', async () => {
+    test('passes an `options` block to plugins', async () => {
         const mockPluginBase = {
-            name: 'sourcebit-mock-plugin1',
             options: {
                 forbiddenElement: {
                     default: 'Arsenic'
@@ -104,6 +105,7 @@ describe('`bootstrapAll()`', () => {
         };
         const mockPlugin1 = {
             ...mockPluginBase,
+            name: 'sourcebit-mock-plugin1',
             bootstrap: jest.fn(({ options }) => {
                 expect(options.forbiddenElement).toEqual(mockPluginBase.options.forbiddenElement.default);
                 expect(options.requiredElement).toEqual(mockPluginBase.options.requiredElement.default);
@@ -111,6 +113,7 @@ describe('`bootstrapAll()`', () => {
         };
         const mockPlugin2 = {
             ...mockPluginBase,
+            name: 'sourcebit-mock-plugin2',
             bootstrap: jest.fn(({ options }) => {
                 expect(options.forbiddenElement).toEqual('Cadmium');
                 expect(options.requiredElement).toEqual('Calcium');
@@ -118,6 +121,7 @@ describe('`bootstrapAll()`', () => {
         };
         const mockPlugin3 = {
             ...mockPluginBase,
+            name: 'sourcebit-mock-plugin3',
             bootstrap: jest.fn(({ options }) => {
                 expect(options.forbiddenElement).toEqual(mockPluginBase.options.forbiddenElement.default);
                 expect(options.requiredElement).toEqual('Magnesium');
@@ -152,6 +156,50 @@ describe('`bootstrapAll()`', () => {
         await sourcebit1.bootstrapAll();
         await sourcebit2.bootstrapAll();
         await sourcebit3.bootstrapAll();
+    });
+
+    test('uses the value of an environment variable named after the `env` option as a default value', async () => {
+        const mockPluginBase = {
+            options: {
+                forbiddenElement: {
+                    env: 'FORBIDDEN_ELEMENT',
+                    default: 'Arsenic'
+                }
+            }
+        };
+        const mockPlugin1 = {
+            ...mockPluginBase,
+            name: 'sourcebit-mock-plugin1',
+            bootstrap: jest.fn(({ options }) => {
+                expect(options.forbiddenElement).toEqual(process.env.FORBIDDEN_ELEMENT);
+            })
+        };
+        const mockPlugin2 = {
+            ...mockPluginBase,
+            name: 'sourcebit-mock-plugin2',
+            bootstrap: jest.fn(({ options }) => {
+                expect(options.forbiddenElement).toEqual('Einsteinium');
+            })
+        };
+        const config1 = {
+            plugins: [{ module: mockPlugin1 }]
+        };
+        const config2 = {
+            plugins: [
+                {
+                    module: mockPlugin2,
+                    options: { forbiddenElement: 'Einsteinium' }
+                }
+            ]
+        };
+        const sourcebit1 = new Sourcebit();
+        const sourcebit2 = new Sourcebit();
+
+        sourcebit1.loadPlugins(config1.plugins);
+        sourcebit2.loadPlugins(config2.plugins);
+
+        await sourcebit1.bootstrapAll();
+        await sourcebit2.bootstrapAll();
     });
 
     test('passes a `getPluginContext` method to plugins', async () => {


### PR DESCRIPTION
This PR makes Sourcebit look for the value of environment variables defined in the `env` property of the plugin's options block, using it as a default value instead of the `default` key.