### PR TITLE
Adds support for configuration of the cacheFilePath

### DIFF
--- a/lib/sourcebit.js
+++ b/lib/sourcebit.js
@@ -14,7 +14,7 @@ const FILE_WRITERS = {
 
 class Sourcebit {
     constructor({ cacheFile = path.join(process.cwd(), '.sourcebit-cache.json'), runtimeParameters = {}, transformCallback } = {}) {
-        this.cacheFilePath = cacheFile;
+        this.cacheFilePath = runtimeParameters.cacheFile === undefined ? cacheFile : runtimeParameters.cacheFile;
         this.context = {};
         this.fileWriterCache = [];
         this.onTransform = transformCallback;


### PR DESCRIPTION
Example Usage:

```
const withSourcebit = require('sourcebit').sourcebitNext({
  config: sourcebitConfig,
  runtimeParameters: {
    cacheFile: join(__dirname, '.sourcebit-cache.json'),
  },
});
```

This small change (pending further testing) should allow for multiple concurrent instances loading into separate caches. This may come in handy for monorepo usages.


Cheers!
~Aaron